### PR TITLE
vite-config: do not open browser

### DIFF
--- a/frontends/apps/web/vite.config.js
+++ b/frontends/apps/web/vite.config.js
@@ -18,7 +18,6 @@ export default defineConfig({
         },
     },
     server: {
-        open: true,
         port: 3000,
         proxy: {
             "/api": {


### PR DESCRIPTION
In my opinion, this option makes not much sense in a server environment without a desktop environment.
There is only an error message displayed in the Docker container log.