### PR TITLE
Fix typo in super-votes refund message

### DIFF
--- a/src/routes/_main/_private/features-vote/route.tsx
+++ b/src/routes/_main/_private/features-vote/route.tsx
@@ -184,7 +184,7 @@ function FeatureVotesPage() {
                                 </div>
                             </div>
                             <div className="text-xs text-muted-foreground">
-                                Super-votes are refund automatically when a feature ships or gets rejected.
+                                Super-votes are refunded automatically when a feature ships or gets rejected.
                             </div>
                             <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
                                 <div className="rounded-lg border px-3 py-2">


### PR DESCRIPTION
This pull request makes a minor correction to the user interface text on the feature votes page, fixing a typo for clarity.

- Fixed a typo in the super-votes refund message, changing "refund" to "refunded" in the `FeatureVotesPage` component (`src/routes/_main/_private/features-vote/route.tsx`).