### PR TITLE
add back button for iOS standalone navigation

### DIFF
--- a/src/lib/client/components/general/PwaNavControls.tsx
+++ b/src/lib/client/components/general/PwaNavControls.tsx
@@ -1,0 +1,78 @@
+import {useEffect, useState} from "react";
+import {useRouter} from "@tanstack/react-router";
+import {ArrowLeft, ArrowRight} from "lucide-react";
+import {Button} from "@/lib/client/components/ui/button";
+
+
+interface HistoryPosition {
+    current: number;
+    furthest: number;
+}
+
+
+export const PwaNavControls = () => {
+    const router = useRouter();
+    const [isIosStandalone, setIsIosStandalone] = useState(false);
+    const [historyPosition, setHistoryPosition] = useState<HistoryPosition>(() => {
+        const current = router.history.location.state.__TSR_index;
+        return { current, furthest: current };
+    });
+
+    useEffect(() => {
+        const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+        const isStandalone = window.matchMedia("(display-mode: standalone)").matches
+            || (navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+        setIsIosStandalone(isIos && isStandalone);
+    }, []);
+
+    useEffect(() => {
+        return router.history.subscribe(({ location, action }) => {
+            const current = location.state.__TSR_index;
+
+            setHistoryPosition((prev) => ({
+                current,
+                furthest: action.type === "PUSH" ? current : Math.max(prev.furthest, current),
+            }));
+        });
+    }, [router.history]);
+
+    if (!isIosStandalone) return null;
+
+    const canGoBack = historyPosition.current > 0;
+    const canGoForward = historyPosition.current < historyPosition.furthest;
+
+    return (
+        <nav
+            aria-label="Page history"
+            style={{ bottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
+            className="fixed left-1/2 z-40 flex -translate-x-1/2 items-center gap-0.5 rounded-full border
+            border-border/80 bg-background/80 p-1 shadow-lg shadow-black/25 backdrop-blur-xl"
+        >
+            <Button
+                size="icon-lg"
+                variant="ghost"
+                aria-label="Go back"
+                disabled={!canGoBack}
+                onClick={() => router.history.back()}
+                className="rounded-full text-muted-foreground"
+            >
+                <ArrowLeft className="size-5"/>
+            </Button>
+
+            <div aria-hidden="true" className="h-5 w-px bg-border"/>
+
+            <Button
+                size="icon-lg"
+                variant="ghost"
+                aria-label="Go forward"
+                disabled={!canGoForward}
+                onClick={() => router.history.forward()}
+                className="rounded-full text-muted-foreground"
+            >
+                <ArrowRight className="size-5"/>
+            </Button>
+        </nav>
+    );
+};

--- a/src/lib/client/components/navbar/Navbar.tsx
+++ b/src/lib/client/components/navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {cva} from "class-variance-authority";
 import authClient from "@/lib/utils/auth-client";
 import {useAuth} from "@/lib/client/hooks/use-auth";
@@ -9,7 +9,7 @@ import {useAuthModal} from "@/lib/client/hooks/use-auth-modal";
 import {SearchBar} from "@/lib/client/components/navbar/SearchBar";
 import {authOptions} from "@/lib/client/react-query/query-options";
 import {PrivacyIcon} from "@/lib/client/components/general/MainIcons";
-import {Link, useLocation, useNavigate} from "@tanstack/react-router";
+import {Link, useLocation, useNavigate, useRouter} from "@tanstack/react-router";
 import {MyMediaMenu} from "@/lib/client/components/navbar/MyMediaMenu";
 import {ProfileIcon} from "@/lib/client/components/general/ProfileIcon";
 import {Notifications} from "@/lib/client/components/navbar/Notifications";
@@ -25,6 +25,7 @@ import {
 } from "@/lib/client/components/ui/dropdown-menu";
 import {
     Activity,
+    ArrowLeft,
     BarChart2,
     ChevronDown,
     Clapperboard,
@@ -53,6 +54,7 @@ const mobileNavStyle = "flex flex-col items-center gap-1 rounded-md p-1 text-mut
 
 
 export const Navbar = () => {
+    const router = useRouter();
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();
@@ -60,6 +62,16 @@ export const Navbar = () => {
     const { openLogin, openRegister } = useAuthModal();
     const featureFlagMutation = useFeatureFlagMutation();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const [isIosStandalone, setIsIosStandalone] = useState(false);
+
+    useEffect(() => {
+        const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+        const isStandalone = window.matchMedia("(display-mode: standalone)").matches
+            || (navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+        setIsIosStandalone(isIos && isStandalone);
+    }, []);
 
     const logoutUser = async () => {
         await authClient.signOut();
@@ -77,25 +89,42 @@ export const Navbar = () => {
         <nav className="sticky top-0 z-50 w-full bg-background border-b">
             <div className="max-w-7xl mx-auto px-4 md:px-8">
                 <div className="flex items-center justify-between h-16 gap-4">
-                    {isAnonymous ?
-                        <Link to="/">
-                            <div className="flex shrink-0 items-center gap-2">
-                                <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
-                                <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
-                                    MyLists
-                                </span>
-                            </div>
-                        </Link>
-                        :
-                        <Link to="/profile/$username" params={{ username: currentUser.name }}>
-                            <div className="flex shrink-0 items-center gap-2">
-                                <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
-                                <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
-                                    MyLists
-                                </span>
-                            </div>
-                        </Link>
-                    }
+                    <div className="flex shrink-0 items-center gap-1">
+                        {isIosStandalone && router.history.canGoBack() &&
+                            <Button
+                                size="icon-lg"
+                                variant="ghost"
+                                aria-label="Go back"
+                                className="text-muted-foreground"
+                                onClick={() => {
+                                    setIsMobileMenuOpen(false);
+                                    router.history.back();
+                                }}
+                            >
+                                <ArrowLeft className="size-5"/>
+                            </Button>
+                        }
+
+                        {isAnonymous ?
+                            <Link to="/">
+                                <div className="flex shrink-0 items-center gap-2">
+                                    <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
+                                    <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
+                                        MyLists
+                                    </span>
+                                </div>
+                            </Link>
+                            :
+                            <Link to="/profile/$username" params={{ username: currentUser.name }}>
+                                <div className="flex shrink-0 items-center gap-2">
+                                    <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
+                                    <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
+                                        MyLists
+                                    </span>
+                                </div>
+                            </Link>
+                        }
+                    </div>
 
                     <div className="flex-1 max-w-md z-50 block max-lg:hidden">
                         <SearchBar/>

--- a/src/lib/client/components/navbar/Navbar.tsx
+++ b/src/lib/client/components/navbar/Navbar.tsx
@@ -1,15 +1,16 @@
-import {useEffect, useState} from "react";
+import {useState} from "react";
 import {cva} from "class-variance-authority";
 import authClient from "@/lib/utils/auth-client";
 import {useAuth} from "@/lib/client/hooks/use-auth";
 import {useQueryClient} from "@tanstack/react-query";
+import {Badge} from "@/lib/client/components/ui/badge";
 import {capitalize} from "@/lib/utils/text-formatting";
 import {Button} from "@/lib/client/components/ui/button";
 import {useAuthModal} from "@/lib/client/hooks/use-auth-modal";
 import {SearchBar} from "@/lib/client/components/navbar/SearchBar";
 import {authOptions} from "@/lib/client/react-query/query-options";
 import {PrivacyIcon} from "@/lib/client/components/general/MainIcons";
-import {Link, useLocation, useNavigate, useRouter} from "@tanstack/react-router";
+import {Link, useLocation, useNavigate} from "@tanstack/react-router";
 import {MyMediaMenu} from "@/lib/client/components/navbar/MyMediaMenu";
 import {ProfileIcon} from "@/lib/client/components/general/ProfileIcon";
 import {Notifications} from "@/lib/client/components/navbar/Notifications";
@@ -25,7 +26,6 @@ import {
 } from "@/lib/client/components/ui/dropdown-menu";
 import {
     Activity,
-    ArrowLeft,
     BarChart2,
     ChevronDown,
     Clapperboard,
@@ -41,11 +41,11 @@ import {
     UsersRound,
     X,
 } from "lucide-react";
-import {Badge} from "@/lib/client/components/ui/badge";
 
 
-const navStyle = cva("inline-flex items-center justify-center rounded-md px-4 text-sm font-medium hover:text-brand " +
-    "outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50"
+const navStyle = cva("inline-flex items-center justify-center rounded-md px-4 text-sm " +
+    "font-medium hover:text-brand outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none " +
+    "disabled:opacity-50"
 )
 
 
@@ -54,7 +54,6 @@ const mobileNavStyle = "flex flex-col items-center gap-1 rounded-md p-1 text-mut
 
 
 export const Navbar = () => {
-    const router = useRouter();
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();
@@ -62,16 +61,6 @@ export const Navbar = () => {
     const { openLogin, openRegister } = useAuthModal();
     const featureFlagMutation = useFeatureFlagMutation();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-    const [isIosStandalone, setIsIosStandalone] = useState(false);
-
-    useEffect(() => {
-        const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
-            || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-        const isStandalone = window.matchMedia("(display-mode: standalone)").matches
-            || (navigator as Navigator & { standalone?: boolean }).standalone === true;
-
-        setIsIosStandalone(isIos && isStandalone);
-    }, []);
 
     const logoutUser = async () => {
         await authClient.signOut();
@@ -89,42 +78,25 @@ export const Navbar = () => {
         <nav className="sticky top-0 z-50 w-full bg-background border-b">
             <div className="max-w-7xl mx-auto px-4 md:px-8">
                 <div className="flex items-center justify-between h-16 gap-4">
-                    <div className="flex shrink-0 items-center gap-1">
-                        {isIosStandalone && router.history.canGoBack() &&
-                            <Button
-                                size="icon-lg"
-                                variant="ghost"
-                                aria-label="Go back"
-                                className="text-muted-foreground"
-                                onClick={() => {
-                                    setIsMobileMenuOpen(false);
-                                    router.history.back();
-                                }}
-                            >
-                                <ArrowLeft className="size-5"/>
-                            </Button>
-                        }
-
-                        {isAnonymous ?
-                            <Link to="/">
-                                <div className="flex shrink-0 items-center gap-2">
-                                    <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
-                                    <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
-                                        MyLists
-                                    </span>
-                                </div>
-                            </Link>
-                            :
-                            <Link to="/profile/$username" params={{ username: currentUser.name }}>
-                                <div className="flex shrink-0 items-center gap-2">
-                                    <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
-                                    <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
-                                        MyLists
-                                    </span>
-                                </div>
-                            </Link>
-                        }
-                    </div>
+                    {isAnonymous ?
+                        <Link to="/">
+                            <div className="flex shrink-0 items-center gap-2">
+                                <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
+                                <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
+                                    MyLists
+                                </span>
+                            </div>
+                        </Link>
+                        :
+                        <Link to="/profile/$username" params={{ username: currentUser.name }}>
+                            <div className="flex shrink-0 items-center gap-2">
+                                <img alt="MyLists logo" className="size-5" src="/logo192.png"/>
+                                <span className="text-xl font-bold text-foreground block tracking-tight max-sm:hidden">
+                                    MyLists
+                                </span>
+                            </div>
+                        </Link>
+                    }
 
                     <div className="flex-1 max-w-md z-50 block max-lg:hidden">
                         <SearchBar/>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import {TooltipProvider} from "@/lib/client/components/ui/tooltip";
 import {ReactQueryDevtools} from "@tanstack/react-query-devtools";
 import {PostHogAuthSync} from "@/lib/client/components/general/PostHogAuthSync";
 import {AuthSessionSync} from "@/lib/client/components/general/AuthSessionSync";
+import {PwaNavControls} from "@/lib/client/components/general/PwaNavControls";
 import {ConfirmDialogHost} from "@/lib/client/components/confirm/ConfirmDialogHost";
 import {AuthModalProvider} from "@/lib/client/components/general/AuthModalProvider";
 import {FeatureVoteLink} from "@/lib/client/components/feature-votes/FeatureVoteLink";
@@ -106,6 +107,7 @@ function AppShell() {
             <Outlet/>
             <Footer/>
             <FeatureVoteLink/>
+            <PwaNavControls/>
         </TooltipProvider>
     );
 }


### PR DESCRIPTION
## Summary

- Add an iOS standalone mode detection in the navbar.
- Show a back button when browser history is available.
- Close the mobile menu before navigating back.

## Testing

- Not run.